### PR TITLE
feat: add IDataverseBatchService for atomic multi-operation change sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/) and this project adheres to Semantic Versioning.
 
+## [1.0.7] - 2026-02-25
+### Added
+- Introduced atomic Dataverse batch change set support via `IDataverseBatchService`, `DataverseBatchService`, and fluent `DataverseBatchBuilder`.
+- Added `DataverseBatchOperation` and parsed batch response models (`DataverseBatchResult`, `DataverseBatchOperationResult`) for ordered per-operation outcomes and created entity ID lookup by `content-id`.
+- Added `DataverseKey` as a first-class key type supporting GUID, alternate key, composite alternate key, and raw OData key expression scenarios.
+
+### Changed
+- Expanded README documentation for the new batch feature, including fluent change set usage and direct operation patterns.
+- Expanded README guidance for `DataverseKey` usage across repositories, lookups, and batch operations.
+
 ## [1.0.6] - 2026-02-23
 ### Changed
 - Expanded README documentation for `Lookup<T>` usage, including DTO property definitions and assignment patterns (GUID, nullable GUID, alternate key, and raw key expression).

--- a/src/Dataverse/Batch/DataverseBatchBuilder.cs
+++ b/src/Dataverse/Batch/DataverseBatchBuilder.cs
@@ -1,0 +1,92 @@
+using Mavrix.Common.Dataverse.DTO;
+using System.Text.Json;
+
+namespace Mavrix.Common.Dataverse.Batch
+{
+	/// <summary>
+	/// Fluent builder for composing Dataverse batch operations and executing them as a change set.
+	/// </summary>
+	/// <example>
+	/// <code>
+	/// var result = await batchService
+	///     .CreateChangeSet()
+	///     .Update(new DataverseKey("emailaddress1", "ada@example.com"), new Contact(), contentId: 1)
+	///     .Create(new Account(), contentId: 2)
+	///     .ExecuteAsync(cancellationToken);
+	/// </code>
+	/// </example>
+	public sealed class DataverseBatchBuilder
+	{
+		private readonly IDataverseBatchService _batchService;
+		private readonly JsonSerializerOptions _jsonSerializerOptions;
+		private readonly List<DataverseBatchOperation> _operations = [];
+
+		internal DataverseBatchBuilder(IDataverseBatchService batchService, JsonSerializerOptions jsonSerializerOptions)
+		{
+			_batchService = batchService;
+			_jsonSerializerOptions = jsonSerializerOptions;
+		}
+
+		/// <summary>
+		/// Adds a create operation to the change set.
+		/// </summary>
+		public DataverseBatchBuilder Create<TTable>(
+			TTable payload,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			_operations.Add(DataverseBatchOperation.Create(payload, _jsonSerializerOptions, contentId, headers));
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an update operation to the change set.
+		/// </summary>
+		public DataverseBatchBuilder Update<TTable>(
+			DataverseKey key,
+			TTable payload,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			_operations.Add(DataverseBatchOperation.Update(key, payload, _jsonSerializerOptions, contentId, headers));
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an upsert operation to the change set.
+		/// </summary>
+		public DataverseBatchBuilder Upsert<TTable>(
+			DataverseKey key,
+			TTable payload,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			_operations.Add(DataverseBatchOperation.Upsert(key, payload, _jsonSerializerOptions, contentId, headers));
+			return this;
+		}
+
+		/// <summary>
+		/// Adds a delete operation to the change set.
+		/// </summary>
+		public DataverseBatchBuilder Delete<TTable>(
+			DataverseKey key,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			_operations.Add(DataverseBatchOperation.Delete<TTable>(key, contentId, headers));
+			return this;
+		}
+
+		/// <summary>
+		/// Executes the built operations as a Dataverse atomic change set.
+		/// </summary>
+		public ValueTask<DataverseBatchResult> ExecuteAsync(CancellationToken cancellationToken)
+		{
+			return _batchService.ExecuteChangeSetAsync(_operations, cancellationToken);
+		}
+	}
+}

--- a/src/Dataverse/Batch/DataverseBatchOperation.cs
+++ b/src/Dataverse/Batch/DataverseBatchOperation.cs
@@ -1,0 +1,192 @@
+using Mavrix.Common.Dataverse.CustomAttributes;
+using Mavrix.Common.Dataverse.DTO;
+using System.Collections.ObjectModel;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Mavrix.Common.Dataverse.Batch
+{
+	/// <summary>
+	/// Represents a single write operation in a Dataverse change set.
+	/// </summary>
+	public sealed class DataverseBatchOperation
+	{
+		private const string IfMatchHeaderName = "If-Match";
+		private const string WildcardIfMatchValue = "*";
+
+		private readonly IReadOnlyDictionary<string, string> _headers;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DataverseBatchOperation"/> class.
+		/// </summary>
+		/// <param name="method">HTTP method for the operation (for example <see cref="HttpMethod.Post"/>).</param>
+		/// <param name="uri">Operation URI relative to the Dataverse API root, or a content-id reference path like <c>$1/field</c>.</param>
+		/// <param name="content">Optional request body content.</param>
+		/// <param name="contentId">Optional content-id used for later <c>$n</c> references.</param>
+		/// <param name="headers">Optional operation headers.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="method"/> or <paramref name="uri"/> is null.</exception>
+		/// <exception cref="ArgumentException">Thrown when <paramref name="uri"/> is empty or whitespace.</exception>
+		private DataverseBatchOperation(
+			HttpMethod method,
+			string uri,
+			JsonContent? content = null,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+		{
+			Method = method ?? throw new ArgumentNullException(nameof(method));
+			if (string.IsNullOrWhiteSpace(uri))
+			{
+				throw new ArgumentException("Operation URI must be a non-empty string representing a relative Dataverse resource path or a content-id reference (for example, \"$1/field\").", nameof(uri));
+			}
+
+			Uri = uri;
+			Content = content;
+			ContentId = contentId;
+			_headers = headers is null
+				? new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))
+				: new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase));
+		}
+
+		/// <summary>
+		/// Creates a <c>POST</c> batch operation for a Dataverse table set resolved from <typeparamref name="TTable"/>.
+		/// </summary>
+		/// <typeparam name="TTable">Dataverse table type used to resolve set name.</typeparam>
+		/// <param name="payload">DTO payload to serialize as JSON.</param>
+		/// <param name="jsonSerializerOptions">JSON serializer options.</param>
+		/// <param name="contentId">Optional content-id used for later <c>$n</c> references.</param>
+		/// <param name="headers">Optional operation headers.</param>
+		/// <returns>A configured batch operation.</returns>
+		public static DataverseBatchOperation Create<TTable>(
+			TTable payload,
+			JsonSerializerOptions jsonSerializerOptions,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			return new DataverseBatchOperation(HttpMethod.Post, GetSetName<TTable>(), CreateJsonContent(payload, jsonSerializerOptions), contentId, headers);
+		}
+
+		/// <summary>
+		/// Creates a <c>PATCH</c> batch operation for a Dataverse table set resolved from <typeparamref name="TTable"/> and key.
+		/// </summary>
+		/// <typeparam name="TTable">Dataverse table type used to resolve set name.</typeparam>
+		/// <param name="key">Dataverse key identifying the target record.</param>
+		/// <param name="payload">DTO payload to serialize as JSON.</param>
+		/// <param name="jsonSerializerOptions">JSON serializer options.</param>
+		/// <param name="contentId">Optional content-id used for later <c>$n</c> references.</param>
+		/// <param name="headers">Optional operation headers. This operation always applies <c>If-Match: *</c>.</param>
+		/// <returns>A configured batch operation.</returns>
+		public static DataverseBatchOperation Update<TTable>(
+			DataverseKey key,
+			TTable payload,
+			JsonSerializerOptions jsonSerializerOptions,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			return new DataverseBatchOperation(
+				HttpMethod.Patch,
+				BuildEntityUri<TTable>(key),
+				CreateJsonContent(payload, jsonSerializerOptions),
+				contentId,
+				EnsureUpdateHeaders(headers));
+		}
+
+		/// <summary>
+		/// Creates a <c>PUT</c> batch operation for a Dataverse table set resolved from <typeparamref name="TTable"/> and key.
+		/// </summary>
+		/// <typeparam name="TTable">Dataverse table type used to resolve set name.</typeparam>
+		/// <param name="key">Dataverse key identifying the target record.</param>
+		/// <param name="payload">DTO payload to serialize as JSON.</param>
+		/// <param name="jsonSerializerOptions">JSON serializer options.</param>
+		/// <param name="contentId">Optional content-id used for later <c>$n</c> references.</param>
+		/// <param name="headers">Optional operation headers.</param>
+		/// <returns>A configured batch operation.</returns>
+		public static DataverseBatchOperation Upsert<TTable>(
+			DataverseKey key,
+			TTable payload,
+			JsonSerializerOptions jsonSerializerOptions,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			return new DataverseBatchOperation(HttpMethod.Put, BuildEntityUri<TTable>(key), CreateJsonContent(payload, jsonSerializerOptions), contentId, headers);
+		}
+
+		/// <summary>
+		/// Creates a <c>DELETE</c> batch operation for a Dataverse table set resolved from <typeparamref name="TTable"/> and key.
+		/// </summary>
+		/// <typeparam name="TTable">Dataverse table type used to resolve set name.</typeparam>
+		/// <param name="key">Dataverse key identifying the target record.</param>
+		/// <param name="contentId">Optional content-id used for later <c>$n</c> references.</param>
+		/// <param name="headers">Optional operation headers.</param>
+		/// <returns>A configured batch operation.</returns>
+		public static DataverseBatchOperation Delete<TTable>(
+			DataverseKey key,
+			int? contentId = null,
+			IReadOnlyDictionary<string, string>? headers = null)
+			where TTable : DataverseTable
+		{
+			return new DataverseBatchOperation(HttpMethod.Delete, BuildEntityUri<TTable>(key), null, contentId, headers);
+		}
+
+		/// <summary>
+		/// Gets the HTTP method for the operation.
+		/// </summary>
+		public HttpMethod Method { get; }
+
+		/// <summary>
+		/// Gets the operation URI relative to Dataverse API root, or a content-id reference path.
+		/// </summary>
+		public string Uri { get; }
+
+		/// <summary>
+		/// Gets optional request body content.
+		/// </summary>
+		public JsonContent? Content { get; }
+
+		/// <summary>
+		/// Gets optional content-id for referencing this operation in later requests.
+		/// </summary>
+		public int? ContentId { get; }
+
+		/// <summary>
+		/// Gets optional operation-specific headers.
+		/// </summary>
+		public IReadOnlyDictionary<string, string> Headers => _headers;
+
+		private static JsonContent CreateJsonContent<TPayload>(TPayload payload, JsonSerializerOptions jsonSerializerOptions)
+		{
+			ArgumentNullException.ThrowIfNull(payload);
+			ArgumentNullException.ThrowIfNull(jsonSerializerOptions);
+			return JsonContent.Create(payload, options: jsonSerializerOptions);
+		}
+
+		private static string BuildEntityUri<TTable>(DataverseKey key) where TTable : DataverseTable
+		{
+			return $"{GetSetName<TTable>()}({key.KeyExpression})";
+		}
+
+		private static Dictionary<string, string> EnsureUpdateHeaders(IReadOnlyDictionary<string, string>? headers)
+		{
+			var result = headers is null
+				? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+				: new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+
+			result[IfMatchHeaderName] = WildcardIfMatchValue;
+			return result;
+		}
+
+		private static string GetSetName<TTable>() where TTable : DataverseTable
+		{
+			var setNameAttribute = typeof(TTable).GetCustomAttribute<DataverseSetNameAttribute>();
+			if (setNameAttribute is null || string.IsNullOrWhiteSpace(setNameAttribute.SetName))
+			{
+				throw new InvalidOperationException($"Type {typeof(TTable).Name} must be decorated with DataverseSetNameAttribute.");
+			}
+
+			return setNameAttribute.SetName;
+		}
+	}
+}

--- a/src/Dataverse/Batch/DataverseBatchResponseParser.cs
+++ b/src/Dataverse/Batch/DataverseBatchResponseParser.cs
@@ -1,0 +1,305 @@
+namespace Mavrix.Common.Dataverse.Batch
+{
+	internal static class DataverseBatchResponseParser
+	{
+		private const string CrLf = "\r\n";
+		private const string DoubleCrLf = "\r\n\r\n";
+		private const string BoundaryParameterName = "boundary";
+		private const string BoundaryPrefix = "boundary=";
+		private const string ContentTypeHeaderName = "Content-Type";
+		private const string ContentIdHeaderName = "Content-ID";
+		private const string ODataEntityIdHeaderName = "OData-EntityId";
+		private const string MultipartMixedContentType = "multipart/mixed";
+		private const string Http11Prefix = "HTTP/1.1";
+		private static readonly ReadOnlyMemory<char> CrLfMemory = CrLf.AsMemory();
+
+		public static async ValueTask<DataverseBatchResult> ParseAsync(HttpContent responseContent, CancellationToken cancellationToken)
+		{
+			var contentType = responseContent.Headers.ContentType;
+			if (contentType is null)
+			{
+				return new DataverseBatchResult();
+			}
+
+			var boundaryParameter = contentType.Parameters
+				.FirstOrDefault(parameter => parameter.Name?.Equals(BoundaryParameterName, StringComparison.OrdinalIgnoreCase) == true);
+
+			var boundary = boundaryParameter?.Value?.Trim().Trim('"');
+			if (string.IsNullOrWhiteSpace(boundary))
+			{
+				return new DataverseBatchResult();
+			}
+
+			var payload = await responseContent.ReadAsStringAsync(cancellationToken);
+			var operationResults = new List<DataverseBatchOperationResult>();
+			ParseMultipartSections(payload.AsSpan(), boundary.AsSpan(), operationResults);
+
+			return new DataverseBatchResult
+			{
+				OperationResults = operationResults
+			};
+		}
+
+		private static void ParseOperationResultsFromSection(ReadOnlySpan<char> section, List<DataverseBatchOperationResult> operationResults)
+		{
+			var headers = SplitHeadersAndBody(section, out var body);
+			if (headers.TryGetValue(ContentTypeHeaderName, out var contentType) && contentType.StartsWith(MultipartMixedContentType, StringComparison.OrdinalIgnoreCase))
+			{
+				var innerBoundary = ExtractBoundary(contentType);
+				if (!string.IsNullOrWhiteSpace(innerBoundary))
+				{
+					ParseMultipartSections(body, innerBoundary.AsSpan(), operationResults);
+					return;
+				}
+			}
+
+			if (!body.StartsWith(Http11Prefix.AsSpan(), StringComparison.OrdinalIgnoreCase))
+			{
+				return;
+			}
+
+			var responseRemainder = body;
+			if (!TryReadLine(ref responseRemainder, out var statusLine))
+			{
+				return;
+			}
+
+			var statusCode = ParseStatusCode(statusLine);
+			var responseHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+			while (TryReadLine(ref responseRemainder, out var line))
+			{
+				if (line.IsEmpty)
+				{
+					break;
+				}
+
+				if (TrySplitHeader(line, out var headerName, out var headerValue))
+				{
+					responseHeaders[headerName.ToString()] = headerValue.ToString();
+				}
+			}
+
+			var trimmedResponseBody = responseRemainder.Trim();
+			operationResults.Add(
+				new DataverseBatchOperationResult
+				{
+					ContentId = ParseContentId(headers),
+					StatusCode = statusCode,
+					EntityId = responseHeaders.TryGetValue(ODataEntityIdHeaderName, out var entityIdHeader)
+						? TryParseEntityId(entityIdHeader)
+						: null,
+					ResponseBody = trimmedResponseBody.IsEmpty ? null : trimmedResponseBody.ToString()
+				});
+		}
+
+		private static void ParseMultipartSections(ReadOnlySpan<char> payload, ReadOnlySpan<char> boundary, List<DataverseBatchOperationResult> operationResults)
+		{
+			if (payload.IsEmpty || boundary.IsEmpty)
+			{
+				return;
+			}
+
+			var markerText = $"--{boundary}";
+			var marker = markerText.AsSpan();
+			var cursor = 0;
+
+			while (cursor <= payload.Length)
+			{
+				var relativeBoundaryIndex = payload[cursor..].IndexOf(marker);
+				if (relativeBoundaryIndex < 0)
+				{
+					return;
+				}
+
+				var boundaryIndex = cursor + relativeBoundaryIndex;
+				var sectionStartIndex = boundaryIndex + marker.Length;
+
+				var relativeNextBoundaryIndex = sectionStartIndex <= payload.Length
+					? payload[sectionStartIndex..].IndexOf(marker)
+					: -1;
+				var isLastSection = relativeNextBoundaryIndex < 0;
+
+				ReadOnlySpan<char> section;
+				if (isLastSection)
+				{
+					section = payload[sectionStartIndex..];
+					cursor = payload.Length;
+				}
+				else
+				{
+					var nextBoundaryIndex = sectionStartIndex + relativeNextBoundaryIndex;
+					section = payload[sectionStartIndex..nextBoundaryIndex];
+					cursor = nextBoundaryIndex;
+				}
+
+				var trimmedSection = section.Trim();
+				if (!trimmedSection.IsEmpty && !trimmedSection.SequenceEqual("--".AsSpan()))
+				{
+					ParseOperationResultsFromSection(trimmedSection, operationResults);
+				}
+
+				if (isLastSection)
+				{
+					return;
+				}
+			}
+		}
+
+		private static Dictionary<string, string> SplitHeadersAndBody(ReadOnlySpan<char> section, out ReadOnlySpan<char> body)
+		{
+			var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			var splitIndex = section.IndexOf(DoubleCrLf.AsSpan(), StringComparison.Ordinal);
+
+			if (splitIndex < 0)
+			{
+				body = section;
+				return headers;
+			}
+
+			var headerBlock = section[..splitIndex];
+			while (!headerBlock.IsEmpty)
+			{
+				if (!TryReadLine(ref headerBlock, out var line))
+				{
+					break;
+				}
+
+				if (line.IsEmpty)
+				{
+					continue;
+				}
+
+				if (TrySplitHeader(line, out var headerName, out var headerValue))
+				{
+					headers[headerName.ToString()] = headerValue.ToString();
+				}
+			}
+
+			body = section[(splitIndex + DoubleCrLf.Length)..];
+			return headers;
+		}
+
+		private static string? ExtractBoundary(string contentType)
+		{
+			var segments = contentType.AsSpan();
+			while (!segments.IsEmpty)
+			{
+				var separatorIndex = segments.IndexOf(';');
+				ReadOnlySpan<char> part;
+				if (separatorIndex < 0)
+				{
+					part = segments;
+					segments = [];
+				}
+				else
+				{
+					part = segments[..separatorIndex];
+					segments = segments[(separatorIndex + 1)..];
+				}
+
+				part = part.Trim();
+				if (!part.StartsWith(BoundaryPrefix, StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				var boundary = part[BoundaryPrefix.Length..].Trim();
+				if (boundary.Length >= 2 && boundary[0] == '"' && boundary[^1] == '"')
+				{
+					boundary = boundary[1..^1];
+				}
+
+				return boundary.ToString();
+			}
+
+			return null;
+		}
+
+		private static int ParseStatusCode(ReadOnlySpan<char> statusLine)
+		{
+			if (statusLine.IsEmpty)
+			{
+				return 0;
+			}
+
+			statusLine = statusLine.Trim();
+			var firstSpace = statusLine.IndexOf(' ');
+			if (firstSpace < 0)
+			{
+				return 0;
+			}
+
+			var remainder = statusLine[(firstSpace + 1)..];
+			remainder = remainder.TrimStart();
+			var nextSpace = remainder.IndexOf(' ');
+			var statusCodeSpan = nextSpace >= 0 ? remainder[..nextSpace] : remainder;
+
+			return int.TryParse(statusCodeSpan, out var statusCode) ? statusCode : 0;
+		}
+
+		private static Guid? TryParseEntityId(string entityIdHeader)
+		{
+			var openParenIndex = entityIdHeader.IndexOf('(');
+			if (openParenIndex < 0)
+			{
+				return null;
+			}
+
+			var closeParenIndex = entityIdHeader.LastIndexOf(')');
+			if (closeParenIndex <= openParenIndex)
+			{
+				return null;
+			}
+
+			var id = entityIdHeader[(openParenIndex + 1)..closeParenIndex];
+			return Guid.TryParse(id, out var guid) ? guid : null;
+		}
+
+		private static int? ParseContentId(Dictionary<string, string> headers)
+		{
+			if (headers.TryGetValue(ContentIdHeaderName, out var contentIdValue) && int.TryParse(contentIdValue, out var contentId))
+			{
+				return contentId;
+			}
+
+			return null;
+		}
+
+		private static bool TrySplitHeader(ReadOnlySpan<char> line, out ReadOnlySpan<char> name, out ReadOnlySpan<char> value)
+		{
+			var separatorIndex = line.IndexOf(':');
+			if (separatorIndex < 0)
+			{
+				name = default;
+				value = default;
+				return false;
+			}
+
+			name = line[..separatorIndex].Trim();
+			value = line[(separatorIndex + 1)..].Trim();
+			return !name.IsEmpty;
+		}
+
+		private static bool TryReadLine(ref ReadOnlySpan<char> text, out ReadOnlySpan<char> line)
+		{
+			if (text.IsEmpty)
+			{
+				line = default;
+				return false;
+			}
+
+			var lineBreakIndex = text.IndexOf(CrLfMemory.Span);
+			if (lineBreakIndex < 0)
+			{
+				line = text;
+				text = [];
+				return true;
+			}
+
+			line = text[..lineBreakIndex];
+			text = text[(lineBreakIndex + CrLfMemory.Length)..];
+			return true;
+		}
+	}
+}

--- a/src/Dataverse/Batch/DataverseBatchService.cs
+++ b/src/Dataverse/Batch/DataverseBatchService.cs
@@ -1,0 +1,206 @@
+using Mavrix.Common.Dataverse.Clients;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Mavrix.Common.Dataverse.Batch
+{
+	/// <summary>
+	/// Represents the parsed result of a Dataverse batch execution.
+	/// </summary>
+	public sealed class DataverseBatchResult
+	{
+		/// <summary>
+		/// Gets the operation responses in server return order.
+		/// </summary>
+		public IReadOnlyList<DataverseBatchOperationResult> OperationResults { get; init; } = [];
+
+		/// <summary>
+		/// Gets the created entity identifier for a given content-id, if available.
+		/// </summary>
+		/// <param name="contentId">Content-id of the operation.</param>
+		/// <returns>The entity identifier when present; otherwise <see langword="null"/>.</returns>
+		public Guid? GetCreatedEntityId(int contentId)
+		{
+			var operationResult = OperationResults.FirstOrDefault(result => result.ContentId == contentId);
+			return operationResult?.EntityId;
+		}
+	}
+
+	/// <summary>
+	/// Represents the parsed result of a single operation in a Dataverse batch response.
+	/// </summary>
+	public sealed class DataverseBatchOperationResult
+	{
+		/// <summary>
+		/// Gets the operation content-id.
+		/// </summary>
+		public int? ContentId { get; init; }
+
+		/// <summary>
+		/// Gets the HTTP status code returned for the operation.
+		/// </summary>
+		public int StatusCode { get; init; }
+
+		/// <summary>
+		/// Gets a value indicating whether the operation succeeded.
+		/// </summary>
+		public bool IsSuccessStatusCode => StatusCode is >= 200 and <= 299;
+
+		/// <summary>
+		/// Gets the created/affected entity identifier from OData headers when present.
+		/// </summary>
+		public Guid? EntityId { get; init; }
+
+		/// <summary>
+		/// Gets the raw operation response body when present.
+		/// </summary>
+		public string? ResponseBody { get; init; }
+	}
+
+	/// <summary>
+	/// Service for executing Dataverse batch requests with atomic change sets.
+	/// </summary>
+	public interface IDataverseBatchService
+	{
+		/// <summary>
+		/// Creates a new fluent builder for composing a Dataverse change set.
+		/// </summary>
+		/// <example>
+		/// <code>
+		/// var result = await batchService
+		///     .CreateChangeSet()
+		///     .Update(new DataverseKey("emailaddress1", "ada@example.com"), new Contact(), contentId: 1)
+		///     .Create(new Account(), contentId: 2)
+		///     .ExecuteAsync(cancellationToken);
+		/// </code>
+		/// </example>
+		/// <returns>A new change set builder instance.</returns>
+		DataverseBatchBuilder CreateChangeSet();
+
+		/// <summary>
+		/// Executes write operations in a single Dataverse change set.
+		/// </summary>
+		/// <param name="operations">Operations to execute atomically in order.</param>
+		/// <param name="cancellationToken">Cancellation token for the request.</param>
+		/// <returns>Parsed operation results including content-id, status code, and created entity ids when returned.</returns>
+		ValueTask<DataverseBatchResult> ExecuteChangeSetAsync(IReadOnlyCollection<DataverseBatchOperation> operations, CancellationToken cancellationToken);
+	}
+
+	/// <summary>
+	/// Default implementation for Dataverse batch and change set execution.
+	/// </summary>
+	public sealed class DataverseBatchService : IDataverseBatchService
+	{
+		private const string CrLf = "\r\n";
+		private readonly IDataverseHttpClient _dataverseHttpClient;
+		private readonly JsonSerializerOptions _jsonSerializerOptions;
+		private readonly string _apiPath;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DataverseBatchService"/> class.
+		/// </summary>
+		/// <param name="dataverseHttpClient">Dataverse HTTP client used to send the batch request.</param>
+		/// <param name="jsonSerializerOptions">Shared serializer options used for fluent batch operation payloads.</param>
+		public DataverseBatchService(IDataverseHttpClient dataverseHttpClient, JsonSerializerOptions jsonSerializerOptions)
+		{
+			ArgumentNullException.ThrowIfNull(dataverseHttpClient);
+			ArgumentNullException.ThrowIfNull(jsonSerializerOptions);
+
+			_dataverseHttpClient = dataverseHttpClient;
+			_jsonSerializerOptions = jsonSerializerOptions;
+			_apiPath = new Uri(_dataverseHttpClient.ApiUrl).AbsolutePath.TrimEnd('/');
+		}
+
+		/// <inheritdoc />
+		public DataverseBatchBuilder CreateChangeSet()
+		{
+			return new DataverseBatchBuilder(this, _jsonSerializerOptions);
+		}
+
+		/// <inheritdoc />
+		public async ValueTask<DataverseBatchResult> ExecuteChangeSetAsync(IReadOnlyCollection<DataverseBatchOperation> operations, CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(operations);
+			if (operations.Count == 0)
+			{
+				throw new ArgumentException("At least one operation is required to execute a change set.", nameof(operations));
+			}
+
+			var batchBoundary = $"batch_{Guid.NewGuid()}";
+			var changeSetBoundary = $"changeset_{Guid.NewGuid()}";
+			var payload = await BuildChangeSetPayloadAsync(batchBoundary, changeSetBoundary, operations, cancellationToken);
+
+			var content = new StringContent(payload, Encoding.UTF8);
+			content.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed; boundary=\"{batchBoundary}\"");
+
+			using var response = await _dataverseHttpClient.ExecuteBatchAsync(content, cancellationToken);
+			return await DataverseBatchResponseParser.ParseAsync(response.Content, cancellationToken);
+		}
+
+		private async ValueTask<string> BuildChangeSetPayloadAsync(string batchBoundary, string changeSetBoundary, IReadOnlyCollection<DataverseBatchOperation> operations, CancellationToken cancellationToken)
+		{
+			var payload = new StringBuilder();
+			payload.Append("--").Append(batchBoundary).Append(CrLf);
+			payload.Append("Content-Type: multipart/mixed; boundary=\"").Append(changeSetBoundary).Append('"').Append(CrLf).Append(CrLf);
+
+			var operationIndex = 0;
+			foreach (var operation in operations)
+			{
+				if (operation.Method == HttpMethod.Get)
+				{
+					throw new InvalidOperationException("GET operations are not allowed in a Dataverse change set.");
+				}
+
+				operationIndex++;
+				payload.Append("--").Append(changeSetBoundary).Append(CrLf);
+				payload.Append("Content-Type: application/http").Append(CrLf);
+				payload.Append("Content-Transfer-Encoding: binary").Append(CrLf);
+
+				var contentId = operation.ContentId ?? operationIndex;
+				payload.Append("Content-ID: ").Append(contentId).Append(CrLf).Append(CrLf);
+
+				payload.Append(operation.Method.Method).Append(' ').Append(ResolveOperationRequestUri(operation.Uri)).Append(" HTTP/1.1").Append(CrLf);
+
+				foreach (var header in operation.Headers)
+				{
+					payload.Append(header.Key).Append(": ").Append(header.Value).Append(CrLf);
+				}
+
+				if (operation.Content is null)
+				{
+					payload.Append(CrLf);
+					continue;
+				}
+
+				var contentType = operation.Content.Headers.ContentType?.ToString() ?? "application/json";
+				payload.Append("Content-Type: ").Append(contentType).Append(CrLf).Append(CrLf);
+				payload.Append(await operation.Content.ReadAsStringAsync(cancellationToken)).Append(CrLf);
+			}
+
+			payload.Append("--").Append(changeSetBoundary).Append("--").Append(CrLf);
+			payload.Append("--").Append(batchBoundary).Append("--").Append(CrLf);
+			return payload.ToString();
+		}
+
+		private string ResolveOperationRequestUri(string uri)
+		{
+			if (uri.StartsWith('$'))
+			{
+				return uri;
+			}
+
+			if (Uri.TryCreate(uri, UriKind.Absolute, out var absoluteUri))
+			{
+				return absoluteUri.PathAndQuery;
+			}
+
+			if (uri.StartsWith('/'))
+			{
+				return uri;
+			}
+
+			return $"{_apiPath}/{uri.TrimStart('/')}";
+		}
+	}
+}

--- a/src/Dataverse/ServiceCollectionExtensions.cs
+++ b/src/Dataverse/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mavrix.Common.Dataverse.AuthenticationTokenProvider;
+using Mavrix.Common.Dataverse.Batch;
 using Mavrix.Common.Dataverse.Clients;
 using Mavrix.Common.Dataverse.DTO;
 using Mavrix.Common.Dataverse.Options;
@@ -51,6 +52,8 @@ namespace Mavrix.Common.Dataverse
 
 			services.AddHttpClient<IDataverseHttpClient, DataverseHttpClient>()
 				.AddTooManyRequestRetryHandler();
+
+			services.TryAddSingleton<IDataverseBatchService, DataverseBatchService>();
 
 			return services;
 		}

--- a/tests/Mavrix.Common.Dataverse.Tests/DataverseBatchServiceTests.cs
+++ b/tests/Mavrix.Common.Dataverse.Tests/DataverseBatchServiceTests.cs
@@ -1,0 +1,222 @@
+using Mavrix.Common.Dataverse.Batch;
+using Mavrix.Common.Dataverse.Clients;
+using Mavrix.Common.Dataverse.DTO;
+using NSubstitute;
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using Xunit;
+
+namespace Mavrix.Common.Dataverse.Tests
+{
+	public class DataverseBatchServiceTests
+	{
+		private static readonly JsonSerializerOptions JsonOptions = new();
+
+		[Fact]
+		public async Task ExecuteChangeSetAsync_Builds_Expected_Atomic_Request_Payload()
+		{
+			// Arrange
+			var client = Substitute.For<IDataverseHttpClient>();
+			client.ApiUrl.Returns("https://org.crm4.dynamics.com/api/data/v9.2");
+
+			HttpContent? capturedBatchContent = null;
+			client.ExecuteBatchAsync(Arg.Do<HttpContent>(content => capturedBatchContent = content), Arg.Any<CancellationToken>())
+				.Returns(new HttpResponseMessage(HttpStatusCode.OK));
+
+			var service = new DataverseBatchService(client, JsonOptions);
+
+			var updateOperation = DataverseBatchOperation.Update(
+				new DataverseKey("emailaddress1", "ada.o'brian@example.com"),
+				new Contact
+				{
+					ParentCustomerIdContact = Guid.NewGuid()
+				},
+				JsonOptions,
+				contentId: 1);
+
+			var createOperation = DataverseBatchOperation.Create(
+				new Account(),
+				JsonOptions,
+				contentId: 2);
+
+			// Act
+			var result = await service.ExecuteChangeSetAsync([updateOperation, createOperation], CancellationToken.None);
+
+			// Assert
+			Assert.NotNull(capturedBatchContent);
+			Assert.NotNull(capturedBatchContent!.Headers.ContentType);
+			Assert.Equal("multipart/mixed", capturedBatchContent.Headers.ContentType!.MediaType);
+
+			var payload = await capturedBatchContent.ReadAsStringAsync();
+
+			Assert.Contains("Content-Type: multipart/mixed; boundary=\"changeset_", payload);
+			Assert.Contains("PATCH /api/data/v9.2/contacts(emailaddress1='ada.o''brian@example.com') HTTP/1.1", payload);
+			Assert.Contains("POST /api/data/v9.2/accounts HTTP/1.1", payload);
+			Assert.Contains("Content-ID: 1", payload);
+			Assert.Contains("Content-ID: 2", payload);
+			Assert.Contains("If-Match: *", payload);
+			Assert.Contains("ParentCustomerId_contact@odata.bind", payload);
+			Assert.Contains("\r\n", payload);
+			Assert.Empty(result.OperationResults);
+		}
+
+		[Fact]
+		public async Task ExecuteChangeSetAsync_Returns_Created_EntityIds_From_Batch_Response()
+		{
+			// Arrange
+			var client = Substitute.For<IDataverseHttpClient>();
+			client.ApiUrl.Returns("https://org.crm4.dynamics.com/api/data/v9.2");
+
+			var accountId = Guid.NewGuid();
+			var contactId = Guid.NewGuid();
+			var batchResponse =
+				"--batchresponse_test\r\n" +
+				"Content-Type: multipart/mixed; boundary=changesetresponse_test\r\n\r\n" +
+				"--changesetresponse_test\r\n" +
+				"Content-Type: application/http\r\n" +
+				"Content-Transfer-Encoding: binary\r\n" +
+				"Content-ID: 1\r\n\r\n" +
+				"HTTP/1.1 204 No Content\r\n" +
+				$"OData-EntityId: https://org.crm4.dynamics.com/api/data/v9.2/accounts({accountId})\r\n\r\n" +
+				"--changesetresponse_test\r\n" +
+				"Content-Type: application/http\r\n" +
+				"Content-Transfer-Encoding: binary\r\n" +
+				"Content-ID: 2\r\n\r\n" +
+				"HTTP/1.1 204 No Content\r\n" +
+				$"OData-EntityId: https://org.crm4.dynamics.com/api/data/v9.2/contacts({contactId})\r\n\r\n" +
+				"--changesetresponse_test--\r\n" +
+				"--batchresponse_test--\r\n";
+
+			var response = new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(batchResponse)
+			};
+			response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("multipart/mixed");
+			response.Content.Headers.ContentType.Parameters.Add(new System.Net.Http.Headers.NameValueHeaderValue("boundary", "batchresponse_test"));
+
+			client.ExecuteBatchAsync(Arg.Any<HttpContent>(), Arg.Any<CancellationToken>())
+				.Returns(response);
+
+			var service = new DataverseBatchService(client, JsonOptions);
+
+			var createAccount = DataverseBatchOperation.Create(new Account(), JsonOptions, contentId: 1);
+			var createContact = DataverseBatchOperation.Create(new Contact(), JsonOptions, contentId: 2);
+
+			// Act
+			var result = await service.ExecuteChangeSetAsync([createAccount, createContact], CancellationToken.None);
+
+			// Assert
+			Assert.Equal(2, result.OperationResults.Count);
+			Assert.Equal(accountId, result.GetCreatedEntityId(1));
+			Assert.Equal(contactId, result.GetCreatedEntityId(2));
+			Assert.All(result.OperationResults, operationResult => Assert.True(operationResult.IsSuccessStatusCode));
+		}
+
+		[Fact]
+		public async Task Fluent_ChangeSet_Builder_Uses_Service_For_Execution()
+		{
+			// Arrange
+			var client = Substitute.For<IDataverseHttpClient>();
+			client.ApiUrl.Returns("https://org.crm4.dynamics.com/api/data/v9.2");
+
+			HttpContent? capturedBatchContent = null;
+			client.ExecuteBatchAsync(Arg.Do<HttpContent>(content => capturedBatchContent = content), Arg.Any<CancellationToken>())
+				.Returns(new HttpResponseMessage(HttpStatusCode.OK));
+
+			var service = new DataverseBatchService(client, JsonOptions);
+
+			// Act
+			var result = await service
+				.CreateChangeSet()
+				.Create(new Contact { ParentCustomerIdContact = Guid.NewGuid() }, contentId: 1)
+				.Create(new Account(), contentId: 2)
+				.ExecuteAsync(CancellationToken.None);
+
+			// Assert
+			Assert.NotNull(capturedBatchContent);
+			var payload = await capturedBatchContent!.ReadAsStringAsync();
+			Assert.Contains("POST /api/data/v9.2/contacts HTTP/1.1", payload);
+			Assert.Contains("POST /api/data/v9.2/accounts HTTP/1.1", payload);
+			Assert.Contains("Content-ID: 1", payload);
+			Assert.Contains("Content-ID: 2", payload);
+			Assert.Empty(result.OperationResults);
+		}
+
+		[Fact]
+		public async Task Fluent_ChangeSet_Builder_Supports_Preferred_Update_Then_Create_Pattern()
+		{
+			// Arrange
+			var client = Substitute.For<IDataverseHttpClient>();
+			client.ApiUrl.Returns("https://org.crm4.dynamics.com/api/data/v9.2");
+
+			HttpContent? capturedBatchContent = null;
+			client.ExecuteBatchAsync(Arg.Do<HttpContent>(content => capturedBatchContent = content), Arg.Any<CancellationToken>())
+				.Returns(new HttpResponseMessage(HttpStatusCode.OK));
+
+			var service = new DataverseBatchService(client, JsonOptions);
+
+			// Act
+			var result = await service
+				.CreateChangeSet()
+				.Update(
+					new DataverseKey("emailaddress1", "ada@example.com"),
+					new Contact { ParentCustomerIdContact = Guid.NewGuid() },
+					contentId: 1)
+				.Create(new Account(), contentId: 2)
+				.ExecuteAsync(CancellationToken.None);
+
+			// Assert
+			Assert.NotNull(capturedBatchContent);
+			var payload = await capturedBatchContent!.ReadAsStringAsync();
+			Assert.Contains("PATCH /api/data/v9.2/contacts(emailaddress1='ada@example.com') HTTP/1.1", payload);
+			Assert.Contains("POST /api/data/v9.2/accounts HTTP/1.1", payload);
+			Assert.Contains("If-Match: *", payload);
+			Assert.Contains("Content-ID: 1", payload);
+			Assert.Contains("Content-ID: 2", payload);
+			Assert.Empty(result.OperationResults);
+		}
+
+		[Fact]
+		public async Task ExecuteChangeSetAsync_Throws_When_Get_Operation_Is_Present()
+		{
+			// Arrange
+			var client = Substitute.For<IDataverseHttpClient>();
+			client.ApiUrl.Returns("https://org.crm4.dynamics.com/api/data/v9.2");
+
+			var service = new DataverseBatchService(client, JsonOptions);
+			var constructor = typeof(DataverseBatchOperation).GetConstructor(
+				BindingFlags.Instance | BindingFlags.NonPublic,
+				binder: null,
+				types:
+				[
+					typeof(HttpMethod),
+					typeof(string),
+					typeof(System.Net.Http.Json.JsonContent),
+					typeof(int?),
+					typeof(IReadOnlyDictionary<string, string>)
+				],
+				modifiers: null);
+
+			Assert.NotNull(constructor);
+			var invalidOperation = (DataverseBatchOperation?)constructor!.Invoke([HttpMethod.Get, "contacts", null, null, null]);
+			Assert.NotNull(invalidOperation);
+
+			// Act / Assert
+			await Assert.ThrowsAsync<InvalidOperationException>(() => service.ExecuteChangeSetAsync([invalidOperation!], CancellationToken.None).AsTask());
+		}
+
+		[Fact]
+		public async Task ExecuteChangeSetAsync_Throws_When_Operation_List_Is_Empty()
+		{
+			// Arrange
+			var client = Substitute.For<IDataverseHttpClient>();
+			client.ApiUrl.Returns("https://org.crm4.dynamics.com/api/data/v9.2");
+
+			var service = new DataverseBatchService(client, JsonOptions);
+
+			// Act / Assert
+			await Assert.ThrowsAsync<ArgumentException>(() => service.ExecuteChangeSetAsync([], CancellationToken.None).AsTask());
+		}
+	}
+}


### PR DESCRIPTION
- Introduced IDataverseBatchService to handle batch operations across multiple tables.
- Implemented DataverseBatchBuilder for fluent API to create change sets.
- Added DataverseBatchOperation for defining individual operations in a batch.
- Enhanced DataverseBatchService to execute batch requests and parse responses.
- Updated README.md to document new batch service functionality.
- Added unit tests for DataverseBatchService to ensure correct payload generation and response handling.